### PR TITLE
Retry Yotpo Request if failed with 400

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-yotpo-shopify",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Source plugin for yotpo with shopify products",
   "main": "index.js",
   "scripts": {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,17 +1,26 @@
 import axios from "axios";
 
+const makeYotpoRequest = async (yotpoAppKey, yotpoPerPage, id) => {
+  return await axios.get(
+    `https://api.yotpo.com/v1/widget/${yotpoAppKey}/products/${id}/reviews.json`,
+    {
+      params: {
+        per_page: yotpoPerPage,
+        page: 1
+      }
+    }
+  );
+}
+
 export const getReviews = async ({ productIds, yotpoAppKey, yotpoPerPage }) => {
   const reviews = await Promise.all(
     productIds.map(async id => {
-      const review = await axios.get(
-        `https://api.yotpo.com/v1/widget/${yotpoAppKey}/products/${id}/reviews.json`,
-        {
-          params: {
-            per_page: yotpoPerPage,
-            page: 1
+      const review = await makeYotpoRequest(yotpoAppKey, yotpoPerPage, id)
+        .catch(error => {
+          if (error.response.status === 400) {
+            return await makeYotpoRequest(yotpoAppKey, yotpoPerPage, id)
           }
-        }
-      );
+        })
       return { ...review.data.response, ...{ productId: id } };
     })
   );

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -16,7 +16,7 @@ export const getReviews = async ({ productIds, yotpoAppKey, yotpoPerPage }) => {
   const reviews = await Promise.all(
     productIds.map(async id => {
       const review = await makeYotpoRequest(yotpoAppKey, yotpoPerPage, id)
-        .catch(error => {
+        .catch(async (error) => {
           if (error.response.status === 400) {
             return await makeYotpoRequest(yotpoAppKey, yotpoPerPage, id)
           }


### PR DESCRIPTION
For the past few months Yotpo API started returning 400 errors every few dozen GETs. After some debugging I wasn't able to pinpoint the bug on the plugin's side, so I added a retry condition.

Each time we get a 400 code on a Yotpo request, we'll try again once.

This plugin doesn't make use of `axios-retry` or any similar package, I wanted to keep it as simple as possible. 