### PR TITLE
Adding ability to append the mock object to the reviews list

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -14,6 +14,7 @@ export const sourceNodes = async (
     yotpoPerPage = 149,
     apiVersion = '2019-07',
     createDefaultObject = false,
+    appendDefaultObject = false,
   },
 ) => {
   if (!shopName || !shopifyAccessToken || !yotpoAppKey) {
@@ -57,6 +58,16 @@ export const sourceNodes = async (
       yotpoPerPage,
     })
     console.timeEnd(formatMsg('finished fetching yotpo reviews'))
+
+    if (appendDefaultObject) {
+      reviews.push({
+        productId: mockYotpoResponse.productId,
+        bottomLine: mockYotpoResponse.bottomline,
+        reviews: mockYotpoResponse.reviews,
+        products: mockYotpoResponse.products
+      })
+      console.log('appended mock reviews')
+    }
 
     console.time(formatMsg('finished fetching yotpo questions'))
     const questions = await getQuestions({

--- a/src/mock.js
+++ b/src/mock.js
@@ -44,8 +44,8 @@ export const mockYotpoResponse = {
       imagesData: [
         {
           id: 1,
-          thumbUrl: 'test',
-          originalUrl: 'test',
+          thumbUrl: 'https://via.placeholder.com/75.png?text=Review+image+thumb',
+          originalUrl: 'https://via.placeholder.com/400.png?text=Review+image+original',
         },
       ],
       user: {


### PR DESCRIPTION
Appending the mock object to your actual reviews ensures that all fields will be created in your GraphQL schema at build time.

There are scenarios where some fields may not come back on the response and will not be created in the GraphQL schema causing query errors down the line.

For example.
1. You don't have any reviews with images.
2. You build your site using this plugin
3. GraphQL nodes are created (without imageData fields since your reviews have no images)
4. The build fails because you are trying to query for a field which does not exist on the schema

Appending the mock object ensures the field will exist.